### PR TITLE
feat: Prepare for publication

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,15 +16,9 @@ jobs:
     name: Linting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
       - uses: actions/checkout@v4
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ secrets.GH_PACKAGES_PAT }}
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v2
@@ -35,7 +29,7 @@ jobs:
         with:
           node-version: 20
           cache: pnpm
-          registry-url: "https://registry.npmjs.org"
+          registry-url: "https://npm.pkg.github.com/"
           cache-dependency-path: ./pnpm-lock.yaml
 
       - name: Install dependencies
@@ -48,15 +42,9 @@ jobs:
     name: Testing
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
       - uses: actions/checkout@v4
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ secrets.GH_PACKAGES_PAT }}
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v2
@@ -67,7 +55,7 @@ jobs:
         with:
           node-version: 20
           cache: pnpm
-          registry-url: "https://registry.npmjs.org"
+          registry-url: "https://npm.pkg.github.com/"
           cache-dependency-path: ./pnpm-lock.yaml
 
       - name: Install dependencies
@@ -90,17 +78,12 @@ jobs:
       id-token: write
       issues: write
       pull-requests: write
+      packages: write
 
     steps:
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
       - uses: actions/checkout@v4
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ secrets.GH_PACKAGES_PAT }}
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v2
@@ -111,11 +94,13 @@ jobs:
         with:
           node-version: 20
           cache: pnpm
-          registry-url: "https://registry.npmjs.org"
+          registry-url: "https://npm.pkg.github.com/"
           cache-dependency-path: ./pnpm-lock.yaml
 
       - name: Install dependencies
         run: pnpm install --ignore-scripts --frozen-lockfile --filter lector...
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_PAT }}
 
       - name: Build package
         run: pnpm build --filter @anaralabs/lector
@@ -127,5 +112,5 @@ jobs:
         run: ../../node_modules/.bin/semantic-release
         working-directory: packages/lector
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PACKAGES_PAT }}
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_PAT }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,2 @@
-# Tell tools where packages scoped @anaralabs should be published/fetched
-# (This might seem redundant with publishConfig, but helps ensure consistency)
 @anaralabs:registry=https://npm.pkg.github.com/
-
-# Associate the registry URL with the auth token env variable for publishing
-//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+    //npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}


### PR DESCRIPTION
This pull request updates the workflow configuration to improve compatibility with GitHub Packages and streamline authentication. The changes primarily involve replacing the use of the `actions/create-github-app-token` action with personal access tokens and updating registry URLs and authentication tokens for publishing and fetching packages.

### Workflow configuration updates:

* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL19-R21): Replaced `actions/create-github-app-token` with the use of `GH_PACKAGES_PAT` for authentication, simplifying token management across multiple jobs (`Linting`, `Testing`, and `Release`). [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL19-R21) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL51-R47) [[3]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR81-R86)
* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL38-R32): Updated the `registry-url` from `https://registry.npmjs.org` to `https://npm.pkg.github.com/` to ensure packages are fetched and published from GitHub Packages. [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL38-R32) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL70-R58) [[3]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL114-R103)
* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR81-R86): Added the `packages: write` permission to the `Release` job to enable package publishing.
* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL114-R103): Updated environment variables for `NODE_AUTH_TOKEN` and `GITHUB_TOKEN` to use `GH_PACKAGES_PAT` consistently during package installation and publishing. [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL114-R103) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL130-R116)

### `.npmrc` file update:

* [`.npmrc`](diffhunk://#diff-e813096d69c49812e40e00be9ac8fa14d77f0ec1f97ab4c45cb096b3bedd35deL1-R2): Adjusted the authentication token configuration to use `NODE_AUTH_TOKEN` instead of `GITHUB_TOKEN` for consistency with the workflow updates.