### PR TITLE
chore: Change package name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -103,7 +103,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_PAT }}
 
       - name: Build package
-        run: pnpm build --filter @anaralabs/lector
+        run: pnpm build --filter @zenzen-sol/lector
 
       - name: Set execute permissions
         run: chmod +x ./packages/lector/scripts/prepack.sh

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
-@anaralabs:registry=https://npm.pkg.github.com/
+@zenzen-sol:registry=https://npm.pkg.github.com/
     //npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/packages/lector/package.json
+++ b/packages/lector/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@anaralabs/lector",
+	"name": "@zenzen-sol/lector",
 	"version": "0.0.0-semantically-released",
 	"description": "Headless PDF viewer for React",
 	"author": "andrewdr (https://github.com/andrewdoro)",

--- a/turbo.json
+++ b/turbo.json
@@ -1,31 +1,31 @@
 {
-  "$schema": "https://turbo.build/schema.json",
-  "remoteCache": {
-    "enabled": true
-  },
-  "tasks": {
-    "build": {
-      "dependsOn": ["^build"],
-      "outputs": [".next/**", "!.next/cache/**", "dist/**"]
-    },
-    "lint": {
-      "dependsOn": ["^build"],
-      "inputs": ["../../.prettierrc", "src/**", "package.json"],
-      "outputs": []
-    },
-    "format": {
-      "dependsOn": ["^format"]
-    },
-    "test": {
-      "dependsOn": ["^test"]
-    },
-    "dev": {
-      "persistent": true,
-      "cache": false
-    },
-    "@anaralabs/lector#test": {
-      "outputs": ["dist/**", "coverage/**"],
-      "dependsOn": ["build"]
-    }
-  }
+	"$schema": "https://turbo.build/schema.json",
+	"remoteCache": {
+		"enabled": true
+	},
+	"tasks": {
+		"build": {
+			"dependsOn": ["^build"],
+			"outputs": [".next/**", "!.next/cache/**", "dist/**"]
+		},
+		"lint": {
+			"dependsOn": ["^build"],
+			"inputs": ["../../.prettierrc", "src/**", "package.json"],
+			"outputs": []
+		},
+		"format": {
+			"dependsOn": ["^format"]
+		},
+		"test": {
+			"dependsOn": ["^test"]
+		},
+		"dev": {
+			"persistent": true,
+			"cache": false
+		},
+		"@zenzen-sol/lector#test": {
+			"outputs": ["dist/**", "coverage/**"],
+			"dependsOn": ["build"]
+		}
+	}
 }


### PR DESCRIPTION
This pull request updates the package scope and registry references from `@anaralabs` to `@zenzen-sol` across the project. These changes ensure consistency in the package naming and publishing configuration.

### Updates to package scope and registry:

* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL106-R106): Updated the `pnpm build` command to use the `@zenzen-sol/lector` package scope.
* [`.npmrc`](diffhunk://#diff-e813096d69c49812e40e00be9ac8fa14d77f0ec1f97ab4c45cb096b3bedd35deL1-R1): Changed the registry configuration to use `@zenzen-sol` instead of `@anaralabs`.
* [`packages/lector/package.json`](diffhunk://#diff-d41735956ff6fbc90e6365f8e4cfec86f7a600b9494f6d250b1bad90b0aafc29L2-R2): Renamed the package from `@anaralabs/lector` to `@zenzen-sol/lector` to reflect the new scope.