### PR TITLE
feat: initial commit of zenzen-sol/lector

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,78 +1,69 @@
 {
-  "name": "lector-monorepo",
-  "version": "0.0.0",
-  "description": "Headless PDF viewer for React",
-  "author": "andrewdr (https://github.com/andrewdoro)",
-  "type": "module",
-  "private": "true",
-  "scripts": {
-    "build": "turbo run build ",
-    "lint": "turbo run lint",
-    "format": "turbo run format",
-    "prepare": "husky",
-    "test": "turbo run test",
-    "dev": "turbo run dev"
-  },
-  "devDependencies": {
-    "@commitlint/config-conventional": "^19.6.0",
-    "commitlint": "^19.6.1",
-    "turbo": "^2.3.3"
-  },
-  "keywords": [
-    "pdf",
-    "react",
-    "headless",
-    "viewer",
-    "react-pdf",
-    "anaralabs",
-    "typescript"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/anaralabs/lector.git"
-  },
-  "bugs": {
-    "url": "https://github.com/anaralabs/lector/issues"
-  },
-  "homepage": "https://github.com/anaralabs/lector",
-  "packageManager": "pnpm@9.5.0",
-  "dependencies": {
-    "husky": "^9.1.7",
-    "semantic-release": "^24.2.0"
-  },
-  "commitlint": {
-    "extends": [
-      "@commitlint/config-conventional"
-    ],
-    "rules": {
-      "type-enum": [
-        2,
-        "always",
-        [
-          "build",
-          "chore",
-          "ci",
-          "clean",
-          "doc",
-          "feat",
-          "fix",
-          "perf",
-          "ref",
-          "revert",
-          "style",
-          "test"
-        ]
-      ],
-      "subject-case": [
-        0,
-        "always",
-        "sentence-case"
-      ],
-      "body-leading-blank": [
-        2,
-        "always",
-        true
-      ]
-    }
-  }
+	"name": "lector-monorepo",
+	"version": "0.0.0",
+	"description": "Headless PDF viewer for React",
+	"author": "andrewdr (https://github.com/andrewdoro)",
+	"contributors": ["zenzen-sol (https://github.com/zenzen-sol)"],
+	"type": "module",
+	"private": "true",
+	"scripts": {
+		"build": "turbo run build ",
+		"lint": "turbo run lint",
+		"format": "turbo run format",
+		"prepare": "husky",
+		"test": "turbo run test",
+		"dev": "turbo run dev"
+	},
+	"devDependencies": {
+		"@commitlint/config-conventional": "^19.6.0",
+		"commitlint": "^19.6.1",
+		"turbo": "^2.3.3"
+	},
+	"keywords": [
+		"pdf",
+		"react",
+		"headless",
+		"viewer",
+		"react-pdf",
+		"anaralabs",
+		"typescript"
+	],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/anaralabs/lector.git"
+	},
+	"bugs": {
+		"url": "https://github.com/anaralabs/lector/issues"
+	},
+	"homepage": "https://github.com/anaralabs/lector",
+	"packageManager": "pnpm@9.5.0",
+	"dependencies": {
+		"husky": "^9.1.7",
+		"semantic-release": "^24.2.0"
+	},
+	"commitlint": {
+		"extends": ["@commitlint/config-conventional"],
+		"rules": {
+			"type-enum": [
+				2,
+				"always",
+				[
+					"build",
+					"chore",
+					"ci",
+					"clean",
+					"doc",
+					"feat",
+					"fix",
+					"perf",
+					"ref",
+					"revert",
+					"style",
+					"test"
+				]
+			],
+			"subject-case": [0, "always", "sentence-case"],
+			"body-leading-blank": [2, "always", true]
+		}
+	}
 }


### PR DESCRIPTION
This pull request includes updates to the `package.json` file, focusing on adding a new contributor and simplifying the formatting of the `commitlint` configuration.

### Updates to contributors:
* Added `zenzen-sol` as a contributor to the project. (`package.json`, [package.jsonR6](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R6))

### Simplification of `commitlint` configuration:
* Reformatted the `extends` array in the `commitlint` section to a single-line format. (`package.json`, [package.jsonL44-R45](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L44-R45))
* Reformatted the `rules` section of `commitlint` to use a more compact single-line style for better readability. (`package.json`, [package.jsonL66-R66](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L66-R66))